### PR TITLE
Fix stray HTML tag in material options

### DIFF
--- a/grozs/includes/widgets/class-grozs-widget-options.php
+++ b/grozs/includes/widgets/class-grozs-widget-options.php
@@ -243,7 +243,7 @@ class Grozs_Widget_Options extends Widget_Base {
         }
 
         echo '<div class="grozs-option"><h6>Materiāls</h6><select name="grozs_materials" id="material">';
-        echo '<option value="izveleties" disabled selected>Izvēlēties</option>>';
+        echo '<option value="izveleties" disabled selected>Izvēlēties</option>';
 		echo '<option value="priede">Priede</option>';
         echo '<option value="osis">Osis (iesakām)</option>';
         echo '<option value="ozols">Ozols</option>';


### PR DESCRIPTION
## Summary
- fix extra `>` in "Materiāls" select option HTML

## Testing
- `php -l grozs/includes/widgets/class-grozs-widget-options.php`


------
https://chatgpt.com/codex/tasks/task_e_687f3b86a06c8325849c04e8dada99eb