### PR TITLE
Add nonce verification for cart order AJAX

### DIFF
--- a/grozs/assets/js/grozs-checkout.js
+++ b/grozs/assets/js/grozs-checkout.js
@@ -96,6 +96,7 @@ jQuery(document).ready(function ($) {
             url: grozs_ajax.ajax_url,
             data: {
                 action: 'submit_grozs_order',
+                nonce: grozs_ajax.nonce,
                 form: formData,
                 cart: cart
             },

--- a/grozs/grozs.php
+++ b/grozs/grozs.php
@@ -96,7 +96,8 @@ function grozs_enqueue_assets() {
     );
 
     wp_localize_script('grozs-checkout', 'grozs_ajax', [
-        'ajax_url' => admin_url('admin-ajax.php')
+        'ajax_url' => admin_url('admin-ajax.php'),
+        'nonce'    => wp_create_nonce('grozs_order_nonce'),
     ]);
 }
 add_action('wp_enqueue_scripts', 'grozs_enqueue_assets');

--- a/grozs/includes/handle-order.php
+++ b/grozs/includes/handle-order.php
@@ -7,8 +7,9 @@ add_action('wp_ajax_submit_grozs_order', 'grozs_handle_order');
 add_action('wp_ajax_nopriv_submit_grozs_order', 'grozs_handle_order');
 
 function grozs_handle_order() {
+    check_ajax_referer('grozs_order_nonce', 'nonce');
     $form = $_POST['form'] ?? [];
-	$cart = $_POST['cart'] ?? [];
+        $cart = $_POST['cart'] ?? [];
 
     if (empty($form) || empty($cart)) {
         wp_send_json_error(['message' => 'Trūkst datu.']);


### PR DESCRIPTION
## Summary
- secure AJAX order handler with nonce verification
- pass the nonce to JS via `wp_localize_script`
- send nonce in checkout AJAX request

## Testing
- `php -l grozs/includes/handle-order.php`
- `php -l grozs/grozs.php`


------
https://chatgpt.com/codex/tasks/task_e_687f4a5f3ad08325bed362c77f702a88